### PR TITLE
Fixed response bug

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -15,9 +15,11 @@ class PostsController < ApplicationController
   end
 
   def show
-    @post = Post.find_by(params[:id])
+    @post = Post.find(params[:id])
     @favorite = Favorite.new
     @unlike = Unlike.new
+    # 未実装のため一旦コメントアウト
+    # @bookmark = Bookmark.new
     @user = User.find_by(id: @post.user_id)
     @comments = @post.comments.includes(:user).all
     @comment = @post.comments.build(user_id: current_user.id) if current_user


### PR DESCRIPTION
投稿一覧画面から投稿詳細画面に遷移するとき、必ず`/posts/1`のデータが描画されるようになっていた（どの投稿をクリックしても`/posts/1`の内容が出てきた）ので、遷移元と遷移先のデータが一致するよう修正。